### PR TITLE
Adds dependencies required, but not listed.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
   "homepage": "https://github.com/drupalcommerce/commerce_base",
   "license": "GPL-2.0+",
   "require": {
-      "drupal/commerce": "^2.0",
+      "drupal/commerce": "~2.0",
       "drupal/admin_toolbar": "~1.0",
       "drupal/swiftmailer": "~1.0"
     }

--- a/composer.json
+++ b/composer.json
@@ -9,5 +9,4 @@
       "drupal/admin_toolbar": "~1.0",
       "drupal/swiftmailer": "~1.0"
     }
-
 }

--- a/composer.json
+++ b/composer.json
@@ -3,5 +3,11 @@
   "type": "drupal-profile",
   "description": "Commerce 2.x installation profile",
   "homepage": "https://github.com/drupalcommerce/commerce_base",
-  "license": "GPL-2.0+"
+  "license": "GPL-2.0+",
+  "require": {
+      "drupal/commerce": "^2.0",
+      "drupal/admin_toolbar": "~1.0",
+      "drupal/swiftmailer": "~1.0"
+    }
+
 }


### PR DESCRIPTION
These dependencies are listed in the project repo, but should instead be
required here.

From @stevector: 
>Commerce_base says it relies on lots of contrib modules in commerce_base.info.yml. But none of them are brought into a project when running composer require drupalcommerce/commerce_base.

Once this PR is merged, these dependencies can be [removed](https://github.com/drupalcommerce/project-base/pull/22) from `drupalcommerce/project-base`.