### PR TITLE
adds required shortcut core module dep to fix site install

### DIFF
--- a/commerce_base.info.yml
+++ b/commerce_base.info.yml
@@ -31,6 +31,7 @@ dependencies:
   - taxonomy
   - dblog
   - search
+  - shortcut
   - toolbar
   - field_ui
   - file


### PR DESCRIPTION
https://github.com/drupalcommerce/commerce_base/blob/9.x/commerce_base.install#L25 requires that the core `shortcut` module is enabled. This fixes the site install problem found at: https://github.com/drupalcommerce/project-base/issues/35