### PR TITLE
Allow contact module to be disabled

### DIFF
--- a/commerce_base.info.yml
+++ b/commerce_base.info.yml
@@ -15,7 +15,6 @@ dependencies:
   - config
   - comment
   - contextual
-  - contact
   - menu_link_content
   - datetime
   - block_content
@@ -60,6 +59,8 @@ dependencies:
   # Contrib
   - admin_toolbar:admin_toolbar
   - symfony_mailer:symfony_mailer
+install:
+  - contact
 themes:
   - bartik
   - seven


### PR DESCRIPTION
By using the `install` keyword in the `.info.yml` file, we can allow site's that want to disable modules to do so. 

Closes https://github.com/drupalcommerce/commerce_base/issues/15 